### PR TITLE
Fix hyperon package installation error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install hyperon
+RUN pip install hyperon
+
+# Set up a shell by default
+CMD ["/bin/bash"]

--- a/install_hyperon_from_source.sh
+++ b/install_hyperon_from_source.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Script to build and install hyperon from source for Python 3.13
+
+echo "Installing hyperon from source for Python 3.13..."
+
+# Check if git is installed
+if ! command -v git &> /dev/null; then
+    echo "Git is not installed. Please install git first:"
+    echo "  sudo apt-get install git"
+    exit 1
+fi
+
+# Check if cargo (Rust) is installed
+if ! command -v cargo &> /dev/null; then
+    echo "Rust/Cargo is not installed. Installing Rust..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+fi
+
+# Check if cmake is installed
+if ! command -v cmake &> /dev/null; then
+    echo "CMake is not installed. Please install cmake first:"
+    echo "  sudo apt-get install cmake"
+    exit 1
+fi
+
+# Clone the repository
+echo "Cloning hyperon repository..."
+git clone https://github.com/trueagi-io/hyperon-experimental.git
+
+# Navigate to the directory
+cd hyperon-experimental
+
+# Build the project
+echo "Building hyperon..."
+cd lib
+cargo build --release
+
+# Install Python bindings
+echo "Installing Python bindings..."
+cd ../python
+pip3 install -e .
+
+echo "Installation complete!"
+echo "Try importing hyperon in Python:"
+echo "  python3 -c 'import hyperon; print(\"Hyperon imported successfully!\")'"


### PR DESCRIPTION
Add Dockerfile for Python 3.12 and a build script for Python 3.13 to resolve `hyperon` package installation issues due to Python version incompatibility.

The `hyperon` package currently lacks support for Python 3.13, causing installation failures. These changes provide solutions for using a supported Python 3.12 environment via Docker or building from source for Python 3.13.

---
<a href="https://cursor.com/background-agent?bcId=bc-083b7594-5dcf-4437-b202-df07ed28d8ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-083b7594-5dcf-4437-b202-df07ed28d8ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

